### PR TITLE
feat: chrome.storage + import/export + ajustes na UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,70 @@
+# FolderTab
+ 
+> Sua nova aba. Seus sites. Do seu jeito.
+ 
+---
+ 
+## O problema
+ 
+Você tem um conjunto de sites que abre toda vez que começa a trabalhar — GitHub, Linear, Notion, YouTube, o localhost do projeto. Todo dia, abre um por um. Na ordem errada. Esquece algum. Perde tempo.
+ 
+Abas fixas? Confusão. Bookmarks do navegador? Planos demais, organização de menos.
+ 
+**FolderTab resolve isso.**
+ 
+---
+ 
+## O que é
+ 
+Uma extensão Chrome que substitui a página de nova aba por um painel de atalhos organizados em **pastas hierárquicas**. Você monta uma estrutura que reflete o seu fluxo de trabalho e, quando precisar, abre tudo de uma vez — com um clique.
+ 
+---
+ 
+## Como funciona
+ 
+### Estrutura em pastas
+ 
+Organize seus sites em pastas e subpastas do jeito que faz sentido pra você:
+ 
+```
+Home
+├── 📁 DEV Plataforma
+│   ├── GitHub Projects
+│   └── Linear
+├── 📁 LocalHost
+│   └── localhost:3000
+├── 📁 IA
+│   ├── ChatGPT
+│   └── Claude
+└── 📁 Faculdade
+    └── Portal do Aluno
+```
+ 
+### Abrir tudo de uma vez
+ 
+Clique com o botão do meio em qualquer pasta para abrir todos os sites dela em uma nova janela. Ou selecione sites individualmente e pressione `Enter`.
+ 
+### Busca instantânea
+ 
+Pressione qualquer tecla e comece a digitar — a busca filtra todos os seus sites em tempo real, mostrando o caminho completo da pasta.
+ 
+### Relógio sempre visível
+ 
+Horário e data no canto superior direito. Sem precisar olhar para a barra do sistema.
+ 
+---
+ 
+## Funcionalidades
+ 
+| Funcionalidade                        | Detalhe                                           |
+| ------------------------------------- | ------------------------------------------------- |
+| **Pastas hierárquicas**               | Estruture em quantos níveis precisar              |
+| **Abrir pasta inteira**               | Clique do meio abre todos os sites em nova janela |
+| **Multi-seleção + Enter**             | Selecione sites individuais e abra todos juntos   |
+| **Busca global**                      | Filtra por nome ou URL em toda a estrutura        |
+| **Menu de contexto**                  | Clique direito para editar, renomear ou deletar   |
+| **Sidebar com árvore**                | Navegação rápida por toda a hierarquia            |
+| **Persistência via `chrome.storage`** | Seus dados sincronizam entre dispositivos         |
+| **Favicon automático**                | Ícones carregados via Google Favicons API         |
+ 
+---

--- a/newtab.html
+++ b/newtab.html
@@ -1,13 +1,17 @@
 <!DOCTYPE html>
 <html lang="pt-BR">
+
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>FolderTab</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500&family=Syne:wght@400;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="src/style.css"/>
+  <link
+    href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500&family=Syne:wght@400;600;700&display=swap"
+    rel="stylesheet">
+  <link rel="stylesheet" href="src/style.css" />
 </head>
+
 <body>
   <div id="app">
 
@@ -16,13 +20,15 @@
       <div class="sidebar-header">
         <div class="logo">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
-            <path d="M3 7C3 5.9 3.9 5 5 5H10L12 7H19C20.1 7 21 7.9 21 9V17C21 18.1 20.1 19 19 19H5C3.9 19 3 18.1 3 17V7Z" stroke="currentColor" stroke-width="1.5" fill="none"/>
+            <path
+              d="M3 7C3 5.9 3.9 5 5 5H10L12 7H19C20.1 7 21 7.9 21 9V17C21 18.1 20.1 19 19 19H5C3.9 19 3 18.1 3 17V7Z"
+              stroke="currentColor" stroke-width="1.5" fill="none" />
           </svg>
           <span>FolderTab</span>
         </div>
         <button id="btn-new-root-folder" class="icon-btn" title="Nova pasta raiz">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
-            <path d="M12 5V19M5 12H19" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+            <path d="M12 5V19M5 12H19" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
           </svg>
         </button>
       </div>
@@ -34,13 +40,22 @@
       <!-- Topbar -->
       <header id="topbar">
         <div id="breadcrumb"></div>
+
         <div id="search-wrap">
           <svg width="15" height="15" viewBox="0 0 24 24" fill="none">
-            <circle cx="11" cy="11" r="7" stroke="currentColor" stroke-width="1.8"/>
-            <path d="M16.5 16.5L21 21" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+            <circle cx="11" cy="11" r="7" stroke="currentColor" stroke-width="1.8" />
+            <path d="M16.5 16.5L21 21" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
           </svg>
-          <input id="search-input" type="text" placeholder="Buscar sites e pastas..."/>
+          <input id="search-input" type="text" placeholder="Buscar sites e pastas..." />
           <kbd>⌘K</kbd>
+        </div>
+        <div id="btn-config">
+          <button id="btn-config" class="btn-primary" title="Configurações">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+              <path
+                d="M9.405 1.05c-.413-1.04-2.397-1.04-2.81 0l-.21.53a1.464 1.464 0 0 1-1.91.81l-.52-.21c-1.04-.413-2.09.637-1.677 1.677l.21.52a1.464 1.464 0 0 1-.81 1.91l-.53.21c-1.04.413-1.04 2.397 0 2.81l.53.21a1.464 1.464 0 0 1 .81 1.91l-.21.52c-.413 1.04.637 2.09 1.677 1.677l.52-.21a1.464 1.464 0 0 1 1.91.81l.21.53c.413 1.04 2.397 1.04 2.81 0l.21-.53a1.464 1.464 0 0 1 1.91-.81l.52.21c1.04.413 2.09-.637 1.677-1.677l-.21-.52a1.464 1.464 0 0 1 .81-1.91l.53-.21c1.04-.413 1.04-2.397 0-2.81l-.53-.21a1.464 1.464 0 0 1-.81-1.91l.21-.52c.413-1.04-.637-2.09-1.677-1.677l-.52.21a1.464 1.464 0 0 1-1.91-.81l-.21-.53zM8 10.5A2.5 2.5 0 1 1 8 5a2.5 2.5 0 0 1 0 5z" />
+            </svg>
+          </button>
         </div>
         <div id="clock-wrap">
           <div id="clock"></div>
@@ -56,30 +71,35 @@
             <div class="toolbar-actions">
               <button class="btn-ghost" id="btn-open-all" title="Abrir todas as abas desta pasta">
                 <svg width="15" height="15" viewBox="0 0 24 24" fill="none">
-                  <path d="M4 6H20M4 12H20M4 18H20" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+                  <path d="M4 6H20M4 12H20M4 18H20" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
                 </svg>
                 Abrir todas
               </button>
               <button class="btn-ghost" id="btn-add-site">
                 <svg width="15" height="15" viewBox="0 0 24 24" fill="none">
-                  <circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="1.8"/>
-                  <path d="M12 8V16M8 12H16" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+                  <circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="1.8" />
+                  <path d="M12 8V16M8 12H16" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
                 </svg>
                 Novo site
               </button>
               <button class="btn-ghost" id="btn-add-subfolder">
                 <svg width="15" height="15" viewBox="0 0 24 24" fill="none">
-                  <path d="M3 7C3 5.9 3.9 5 5 5H10L12 7H19C20.1 7 21 7.9 21 9V17C21 18.1 20.1 19 19 19H5C3.9 19 3 18.1 3 17V7Z" stroke="currentColor" stroke-width="1.5"/>
-                  <path d="M12 10V16M9 13H15" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+                  <path
+                    d="M3 7C3 5.9 3.9 5 5 5H10L12 7H19C20.1 7 21 7.9 21 9V17C21 18.1 20.1 19 19 19H5C3.9 19 3 18.1 3 17V7Z"
+                    stroke="currentColor" stroke-width="1.5" />
+                  <path d="M12 10V16M9 13H15" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
                 </svg>
                 Nova subpasta
               </button>
             </div>
           </div>
           <div id="items-grid"></div>
+
           <div id="empty-state" style="display:none">
             <svg width="48" height="48" viewBox="0 0 24 24" fill="none" opacity="0.3">
-              <path d="M3 7C3 5.9 3.9 5 5 5H10L12 7H19C20.1 7 21 7.9 21 9V17C21 18.1 20.1 19 19 19H5C3.9 19 3 18.1 3 17V7Z" stroke="currentColor" stroke-width="1.2"/>
+              <path
+                d="M3 7C3 5.9 3.9 5 5 5H10L12 7H19C20.1 7 21 7.9 21 9V17C21 18.1 20.1 19 19 19H5C3.9 19 3 18.1 3 17V7Z"
+                stroke="currentColor" stroke-width="1.2" />
             </svg>
             <p>Pasta vazia</p>
             <span>Adicione sites ou subpastas acima</span>
@@ -119,4 +139,5 @@
 
   <script src="src/app.js"></script>
 </body>
+
 </html>

--- a/src/app.js
+++ b/src/app.js
@@ -627,13 +627,7 @@ function promptConfig() {
       <input id="s-url" class="field-input" placeholder="https://..." type="url"/>
     </div>
   `, () => {
-    // let name = document.getElementById('s-name').value.trim();
-    // let url = document.getElementById('s-url').value.trim();
-    // if (!url) return;
-    // if (!url.startsWith('http')) url = 'https://' + url;
-    // if (!name) name = url;
-    // const site = { id: uid(), name, url };
-    // state.data.folders[folderId].sites.push(site);
+
     saveData();
     closeModal();
     renderGrid();

--- a/src/app.js
+++ b/src/app.js
@@ -1,73 +1,140 @@
 // ── Storage helpers ──────────────────────────────────
 const STORAGE_KEY = 'foldertab_data';
 
-function loadData() {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (raw) return JSON.parse(raw);
-  } catch (e) { }
-  return defaultData();
+async function loadData() {
+  return new Promise((resolve) => {
+    if (typeof chrome !== 'undefined' && chrome.storage) {
+      chrome.storage.sync.get([STORAGE_KEY], (result) => {
+        if (result[STORAGE_KEY]) {
+          resolve(result[STORAGE_KEY]);
+        } else {
+          resolve(defaultData());
+        }
+      });
+    } else {
+      resolve(defaultData());
+    }
+  });
 }
 
 function saveData() {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(state.data));
-  // Also try chrome.storage.sync if available
   if (typeof chrome !== 'undefined' && chrome.storage) {
-    chrome.storage.sync.set({ foldertab: state.data });
+    chrome.storage.sync.set({
+      [STORAGE_KEY]: state.data
+    });
   }
 }
 
 function defaultData() {
   return {
     folders: {
-      root: {
-        id: 'root',
-        name: 'Root',
-        children: ['f-work', 'f-learn'],
-        sites: [],
-        parentId: null
-      },
-      'f-work': {
-        id: 'f-work',
-        name: 'Trabalho',
-        children: ['f-devtools'],
-        sites: [
-          { id: 's1', name: 'GitHub', url: 'https://github.com' },
-          { id: 's2', name: 'Linear', url: 'https://linear.app' }
-        ],
-        parentId: 'root'
-      },
-      'f-devtools': {
-        id: 'f-devtools',
-        name: 'Dev Tools',
+      "i-i58lz9x": {
         children: [],
+        id: "i-i58lz9x",
+        name: "IA",
+        parentId: "root",
         sites: [
-          { id: 's3', name: 'MDN Docs', url: 'https://developer.mozilla.org' },
-          { id: 's4', name: 'Can I Use', url: 'https://caniuse.com' }
-        ],
-        parentId: 'f-work'
+          { id: "i-44fab1z", name: "Claude", url: "https://claude.ai/new" },
+          { id: "i-kznz8md", name: "Grok", url: "https://grok.com/" },
+          { id: "i-2echh8z", name: "ChatGPT", url: "https://chatgpt.com/" },
+          { id: "i-glep1l0", name: "Gemini", url: "https://gemini.google.com/app?hl=pt-BR" },
+          { id: "i-e2lw4gw", name: "Copilot", url: "https://github.com/copilot" }
+        ]
       },
-      'f-learn': {
-        id: 'f-learn',
-        name: 'Aprendizado',
+
+      "i-ifi124p": {
         children: [],
+        id: "i-ifi124p",
+        name: "Serviços Docker",
+        parentId: "root",
         sites: [
-          { id: 's5', name: 'YouTube', url: 'https://youtube.com' },
-          { id: 's6', name: 'Coursera', url: 'https://coursera.org' }
+          { id: "i-y34x2es", name: "Plex", url: "http://localhost:32400/web/index.html#!/" },
+          { id: "i-nrui4qe", name: "SyncThing - Obsidian", url: "http://localhost:8384/" }
+        ]
+      },
+
+      "i-ujnhhmw": {
+        children: [],
+        id: "i-ujnhhmw",
+        name: "Dev Local",
+        parentId: "root",
+        sites: [
+          { id: "i-wfccqkm", name: "Supabase", url: "http://localhost:54323/project/default" },
+          { id: "i-ial24i6", name: "Next - Dashboard", url: "http://localhost:3000/dashboard" },
+          { id: "i-anpoqbv", name: "FastAPI - Docs", url: "http://localhost:8000/docs" }
+        ]
+      },
+
+      "root": {
+        children: [
+          "i-i58lz9x",
+          "i-ujnhhmw",
+          "i-ifi124p"
         ],
-        parentId: 'root'
+        id: "root",
+        name: "Root",
+        parentId: null,
+        sites: [
+          { id: "i-3dp0um4", name: "Git Projects", url: "https://github.com/projects" },
+          { id: "i-ylr4lfo", name: "Linkedin", url: "https://www.linkedin.com/feed/" }
+        ]
       }
     }
   };
 }
 
+function exportData() {
+  const json = JSON.stringify(state.data, null, 2);
+
+  const blob = new Blob([json], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'foldertab-backup.json';
+  a.click();
+
+  URL.revokeObjectURL(url);
+}
+
+
+function importData(json) {
+  try {
+    const data = JSON.parse(json);
+
+    if (!data || typeof data !== 'object') {
+      throw new Error('JSON inválido');
+    }
+
+    state.data = data;
+    saveData();
+    renderSidebar();
+    renderGrid();
+
+  } catch (err) {
+    alert('Erro ao importar JSON');
+  }
+}
+
+
+function handleFileUpload(file) {
+  const reader = new FileReader();
+
+  reader.onload = (e) => {
+    importData(e.target.result);
+  };
+
+  reader.readAsText(file);
+}
+
+
 // ── State ────────────────────────────────────────────
 const state = {
-  data: loadData(),
+  data: null,
   currentFolderId: 'root',
   searchQuery: '',
-  dragItem: null,        // { type, id, folderId }
-  ctxTarget: null,       // { type, id, folderId }
+  dragItem: null,
+  ctxTarget: null,
   modalCallback: null,
   selectedItems: []
 };
@@ -618,23 +685,37 @@ function promptNewFolder(parentId) {
 
 function promptConfig() {
   openModal('Import / Export', `
+    
     <div class="field-group">
-      <label>Nome</label>
-      <input id="s-name" class="field-input" placeholder="ex: GitHub" maxlength="60"/>
+      <button id="btn-export" class="field-input">📤 Exportar Backup</button>
     </div>
-    <div class="field-group">
-      <label>URL</label>
-      <input id="s-url" class="field-input" placeholder="https://..." type="url"/>
-    </div>
-  `, () => {
 
-    saveData();
+    <div class="field-group">
+      <label>Importar JSON</label>
+      <input type="file" id="import-file" accept="application/json" />
+    </div>
+
+  `, () => {
     closeModal();
-    renderGrid();
   });
+
+  setTimeout(() => {
+
+    // Click no EXPORTAR
+    document.getElementById('btn-export')
+      .addEventListener('click', exportData);
+
+    // IMPORTAR
+    document.getElementById('import-file')
+      .addEventListener('change', (e) => {
+        const file = e.target.files[0];
+        if (file) handleFileUpload(file);
+      });
+
+  }, 50);
 }
 
-// button de exportar dados (JSON)
+// button para abrir modal de importar e exportar dados (JSON)
 document.getElementById('btn-config').addEventListener('click', () => promptConfig());
 
 
@@ -891,19 +972,9 @@ document.getElementById('items-grid').addEventListener('click', (e) => {
 });
 
 // ── Init ──────────────────────────────────────────────
-// Try to restore from chrome.storage
-if (typeof chrome !== 'undefined' && chrome.storage) {
-  chrome.storage.sync.get('foldertab', (result) => {
-    if (result.foldertab) {
-      state.data = result.foldertab;
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(state.data));
-    }
-    boot();
-  });
-} else {
-  boot();
-}
-
-function boot() {
+async function boot() {
+  state.data = await loadData();
   navigateTo('root');
 }
+
+boot();

--- a/src/app.js
+++ b/src/app.js
@@ -1,7 +1,3 @@
-/* ═══════════════════════════════════════════════════
-   FolderTab — app.js
-   ═══════════════════════════════════════════════════ */
-
 // ── Storage helpers ──────────────────────────────────
 const STORAGE_KEY = 'foldertab_data';
 
@@ -73,6 +69,7 @@ const state = {
   dragItem: null,        // { type, id, folderId }
   ctxTarget: null,       // { type, id, folderId }
   modalCallback: null,
+  selectedItems: []
 };
 
 // ── Utilities ────────────────────────────────────────
@@ -231,6 +228,7 @@ function renderBreadcrumb() {
   const bc = document.getElementById('breadcrumb');
   bc.innerHTML = '';
   const path = getFolderPath(state.currentFolderId);
+
   path.forEach((f, i) => {
     if (i > 0) {
       const sep = document.createElement('span');
@@ -240,9 +238,13 @@ function renderBreadcrumb() {
     }
     const item = document.createElement('span');
     item.className = 'bc-item' + (i === path.length - 1 ? ' current' : '');
+
+    if (f.id === 'root') {
+      item.classList.add('bc-home');
+    }
     item.textContent = f.id === 'root' ? '⌂' : f.name;
-    if (i < path.length - 1) {
-      item.addEventListener('click', () => navigateTo(f.id));
+    if (f.id === 'root') {
+      item.addEventListener('click', () => navigateTo('root'));
     }
     bc.appendChild(item);
   });
@@ -308,8 +310,12 @@ function createFolderCard(folder) {
     <div class="item-label">${escHtml(folder.name)}</div>
   `;
 
-  el.addEventListener('dblclick', () => navigateTo(folder.id));
-  el.addEventListener('click', (e) => { e.stopPropagation(); selectItem(el); });
+  el.addEventListener('click', () => navigateTo(folder.id));
+  el.addEventListener('auxclick', (event) => {
+    if (event.button === 1) {
+      openAllTabsNewWindow(folder.id);
+    }
+  });
   el.addEventListener('contextmenu', (e) => {
     e.preventDefault();
     showCtxMenu(e, { type: 'folder', id: folder.id, folderId: folder.parentId });
@@ -362,7 +368,13 @@ function createSiteCard(site, folderId) {
   `;
 
   el.addEventListener('click', (e) => { e.stopPropagation(); selectItem(el); });
-  el.addEventListener('dblclick', () => window.open(site.url, '_blank'));
+  el.addEventListener('dblclick', () => window.open(site.url, '_self'));
+  el.addEventListener('auxclick', (event) => {
+    if (event.button === 1) {
+      window.open(site.url, '_blank');
+    }
+  });
+
   el.addEventListener('contextmenu', (e) => {
     e.preventDefault();
     showCtxMenu(e, { type: 'site', id: site.id, folderId });
@@ -380,9 +392,29 @@ function createSiteCard(site, folderId) {
   return el;
 }
 
+// Seleciona um item (para abrir múltiplos)
+
+function updateSelectedUrls() {
+  const selected = document.querySelectorAll('.grid-item.selected');
+
+  // pega URL correta usando folderId + siteId
+  const urls = Array.from(selected)
+    .map(el => {
+      const folderId = el.dataset.folderId;
+      const siteId = el.dataset.siteId;
+      const folder = state.data.folders[folderId];
+      if (!folder) return null;
+      const site = folder.sites.find(s => s.id === siteId);
+      return site?.url || null;
+    })
+    .filter(Boolean);
+
+  state.selectedUrls = urls;
+}
+
 function selectItem(el) {
-  document.querySelectorAll('.grid-item.selected').forEach(e => e.classList.remove('selected'));
   el.classList.add('selected');
+  updateSelectedUrls();
 }
 
 // ── Navigate ─────────────────────────────────────────
@@ -416,8 +448,17 @@ function openAllTabs(folderId) {
   urls.forEach(url => window.open(url, '_blank'));
 }
 
+function openSelectedLinksFromState() {
+  if (state.selectedUrls.length === 0) {
+    alert('Nenhum site selecionado.');
+    return;
+  }
 
-// ── Open All Tabs ─────────────────────────────────────
+  state.selectedUrls.forEach(url => window.open(url, '_blank'));
+}
+
+
+// ── Open All Tabs New Window ─────────────────────────────────────
 function openAllTabsNewWindow(folderId) {
   const f = state.data.folders[folderId];
   if (!f) return;
@@ -462,10 +503,6 @@ function showCtxMenu(e, target) {
   if (target.type === 'folder') {
     const isRoot = target.id === 'root';
 
-    addCtxItem('🗂️ Abrir pasta', () => navigateTo(target.id));
-    addCtxItem('🚀 Abrir todas as abas', () => openAllTabs(target.id));
-    addCtxItem('🚀 Abrir todas as abas em nova janela', () => openAllTabsNewWindow(target.id));
-    addCtxSep();
     addCtxItem('✏️ Renomear', () => promptRename(target.id));
     addCtxItem('📁 Nova subpasta', () => promptNewFolder(target.id));
     addCtxItem('🌐 Novo site aqui', () => promptNewSite(target.id));
@@ -576,6 +613,43 @@ function promptNewFolder(parentId) {
   });
 }
 
+
+// função para abrir modal de importar e exportar dados (JSON)
+
+function promptConfig() {
+  openModal('Import / Export', `
+    <div class="field-group">
+      <label>Nome</label>
+      <input id="s-name" class="field-input" placeholder="ex: GitHub" maxlength="60"/>
+    </div>
+    <div class="field-group">
+      <label>URL</label>
+      <input id="s-url" class="field-input" placeholder="https://..." type="url"/>
+    </div>
+  `, () => {
+    // let name = document.getElementById('s-name').value.trim();
+    // let url = document.getElementById('s-url').value.trim();
+    // if (!url) return;
+    // if (!url.startsWith('http')) url = 'https://' + url;
+    // if (!name) name = url;
+    // const site = { id: uid(), name, url };
+    // state.data.folders[folderId].sites.push(site);
+    saveData();
+    closeModal();
+    renderGrid();
+  });
+}
+
+// button de exportar dados (JSON)
+document.getElementById('btn-config').addEventListener('click', () => promptConfig());
+
+
+
+
+
+
+
+
 function promptRename(folderId) {
   const f = state.data.folders[folderId];
   if (!f || folderId === 'root') return;
@@ -684,7 +758,7 @@ function deleteSite(folderId, siteId) {
 document.getElementById('btn-add-site').addEventListener('click', () => promptNewSite(state.currentFolderId));
 document.getElementById('btn-add-subfolder').addEventListener('click', () => promptNewFolder(state.currentFolderId));
 document.getElementById('btn-new-root-folder').addEventListener('click', () => promptNewFolder('root'));
-document.getElementById('btn-open-all').addEventListener('click', () => openAllTabs(state.currentFolderId));
+document.getElementById('btn-open-all').addEventListener('click', () => openSelectedLinksFromState());
 
 // ── Drag & Drop ───────────────────────────────────────
 function showDragGhost(name) {
@@ -761,12 +835,11 @@ searchInput.addEventListener('input', () => {
   renderSearchResults(q);
 });
 
-// ⌘K shortcut
+
+// shortcut open selected tabs
 document.addEventListener('keydown', (e) => {
-  if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
-    e.preventDefault();
-    searchInput.focus();
-    searchInput.select();
+  if (e.key === 'Enter') {
+    openSelectedLinksFromState()
   }
 });
 

--- a/src/style.css
+++ b/src/style.css
@@ -180,11 +180,24 @@ body {
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 12px;
+  font-size: 16px;
   color: var(--text3);
   font-family: var(--mono);
   flex-shrink: 0;
   min-width: 0;
+}
+
+.bc-home {
+  font-size: 26px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.bc-home:hover {
+  transform: scale(1.25);
+  transition: 0.2s;
 }
 
 .bc-item {


### PR DESCRIPTION
##  O que foi feito

* Substitui `localStorage` por `chrome.storage`
* Adiciona importação e exportação de dados em JSON no modal de config
* Atualiza `defaultData()` com um snapshot inicial
* Adiciona botão de config no header
* Ajustes na navegação:

  * Clique único entra na pasta
  * Links abrem na mesma aba (`_self`)
* Implementa seleção de links (`selectedItems`) + abrir múltiplos (botão e shortcut)
* Pequenas melhorias visuais no breadcrumb (`bc-home`)

---

## 🔗 Issues relacionadas

Closes #1 
Closes #4 
Closes #5 

---

